### PR TITLE
Update FC_SymmetrizeOperator to use Python's type annotations

### DIFF
--- a/fc_utils_op.py
+++ b/fc_utils_op.py
@@ -78,7 +78,7 @@ class FC_SymmetrizeOperator(Operator):
     bl_description = "Symmetrize selected object" 
     bl_options = {'REGISTER', 'UNDO'}
     
-    sym_axis = StringProperty(name="Symmetry axis", options={'HIDDEN'}, default="NEGATIVE_X")
+    sym_axis: StringProperty(name="Symmetry axis", options={'HIDDEN'}, default="NEGATIVE_X")
     
         
     @classmethod


### PR DESCRIPTION
I'm not sure if you're taking pull requests but I was looking at the console (for an unrelated issue to primitive mode disappearing) and I saw this warning:

```
Warning: class OBJECT_OT_sym contains a properties which should be an annotation!
...\Blender Foundation\Blender\2.80\scripts\addons\fast-carve-fast-carve-2-8\__init__.py:126
    make annotation: OBJECT_OT_sym.sym_axis
```

I updated the code locally and tested it and everything still appears to work as expected.